### PR TITLE
Make TopKQueue thread-safe. Get rid of similarityHolder.

### DIFF
--- a/pkg/suggest/suggester.go
+++ b/pkg/suggest/suggester.go
@@ -57,11 +57,6 @@ func (n *nGramSuggester) Suggest(config SearchConfig) ([]Candidate, error) {
 		bMax = lenIndices - 1
 	}
 
-	// store similarity as atomic value
-	// we are going to update its value after search sub-work complete
-	similarityHolder := utils.AtomicFloat64{}
-	similarityHolder.Store(config.similarity)
-
 	topKQueue := topKQueuePool.Get().(TopKQueue)
 	topKQueue.Reset(config.topK)
 	defer topKQueuePool.Put(topKQueue)
@@ -69,12 +64,11 @@ func (n *nGramSuggester) Suggest(config SearchConfig) ([]Candidate, error) {
 	// channel that receives fuzzyCollector and performs a search on length segment
 	sizeCh := make(chan int, bMax-bMin+1)
 	workerPool := errgroup.Group{}
-	lock := sync.Mutex{}
 
 	for i := 0; i < utils.Min(maxSearchQueriesAtOnce, bMax-bMin+1); i++ {
 		workerPool.Go(func() error {
 			for sizeB := range sizeCh {
-				similarity := similarityHolder.Load()
+				similarity := utils.MaxFloat64(config.similarity, topKQueue.GetLowestScore())
 				threshold := config.metric.Threshold(similarity, sizeA, sizeB)
 
 				// it means that the similarity has been changed and we will skip this value processing
@@ -88,29 +82,14 @@ func (n *nGramSuggester) Suggest(config SearchConfig) ([]Candidate, error) {
 					continue
 				}
 
-				queue := topKQueuePool.Get().(TopKQueue)
-				queue.Reset(config.topK)
-
 				collector := &fuzzyCollector{
-					topKQueue: queue,
+					topKQueue: topKQueue,
 					scorer:    NewMetricScorer(config.metric, sizeA, sizeB),
 				}
 
 				if err := n.searcher.Search(invertedIndex, set, threshold, collector); err != nil {
 					return fmt.Errorf("failed to search posting lists: %w", err)
 				}
-
-				lock.Lock()
-
-				topKQueue.Merge(queue)
-
-				if topKQueue.IsFull() && similarityHolder.Load() < topKQueue.GetLowestScore() {
-					similarityHolder.Store(topKQueue.GetLowestScore())
-				}
-
-				lock.Unlock()
-
-				topKQueuePool.Put(queue)
 			}
 
 			return nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,6 +24,15 @@ func Min(a, b int) int {
 	return a
 }
 
+// MaxFloat64 returns the maximum value
+func MaxFloat64(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+
+	return b
+}
+
 // Pack packs 2 uint32 into uint64
 func Pack(a, b uint32) uint64 {
 	return (uint64(a) << 32) | uint64(b&math.MaxUint32)


### PR DESCRIPTION
This PR makes a `TopKQueue` thread-safe and reuses it in different collectors. There are some improvement diffs:

```
benchmark                              old ns/op     new ns/op     delta
BenchmarkSuggest-8                     17364         15893         -8.47%
BenchmarkAutoComplete-8                12175         12366         +1.57%
BenchmarkRealExampleInMemory-8         42058         41371         -1.63%
BenchmarkRealExampleOnDisc-8           42134         41990         -0.34%
BenchmarkSuggestWordsOnDisc-8          115070        102630        -10.81%
BenchmarkAutocompleteWordsOnDisc-8     48066         47897         -0.35%

benchmark                              old allocs     new allocs     delta
BenchmarkRealExampleInMemory-8         331            267            -19.34%
BenchmarkRealExampleOnDisc-8           331            267            -19.34%
BenchmarkSuggestWordsOnDisc-8          604            547            -9.44%
BenchmarkAutocompleteWordsOnDisc-8     315            315            +0.00%

benchmark                              old bytes     new bytes     delta
BenchmarkRealExampleInMemory-8         15526         13476         -13.20%
BenchmarkRealExampleOnDisc-8           15543         13500         -13.14%
BenchmarkSuggestWordsOnDisc-8          21933         20067         -8.51%
BenchmarkAutocompleteWordsOnDisc-8     12666         12699         +0.26%
```